### PR TITLE
earth-53: Modifies subscription budget names to include environment n…

### DIFF
--- a/releasables/deploy-earth.ps1
+++ b/releasables/deploy-earth.ps1
@@ -30,11 +30,24 @@ function Update-SubscriptionBudget {
 
     process {
         if($PSCmdlet.ShouldProcess($EarthFrontendResourceGroupLocation)) {
+            $StartDate = (Get-Date).ToString("yyyy-MM-01")
+            $EndDate   = (Get-Date).AddYears(2).ToString("yyyy-MM-dd")
+
+            $Parameters = [PSCustomObject]@{
+                budgetName = @{ value = "$EnvironmentName-subscription-budget" }
+                startDate  = @{ value = "$StartDate" }
+                endDate    = @{ value = "$EndDate" }
+            }
+
+            $ParametersJson = $Parameters | ConvertTo-Json
+            $ParametersJson = $ParametersJson.Replace('"', '\"')
+
             az `
                 deployment sub create `
                 --location $EarthFrontendResourceGroupLocation `
                 --template-file azure-subscription/subscription-budget.bicep `
-                --parameters @azure-subscription/subscription-budget.parameters.json
+                --parameters @azure-subscription/subscription-budget.parameters.json `
+                --parameters $ParametersJson
 
             if (!$?) {
                 Write-Error "Budget deployment failed."


### PR DESCRIPTION
…ames so that when a budget alert is received it's clear which subscription/environment the alert is for.