### PR TITLE
earth-227: Converts the GA Tracking ID variable to being only a deplo…

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -110,8 +110,7 @@ function Invoke-Build {
         ./build.ps1 `
             -BuildNumber                    $([Guid]::NewGuid()) `
             -FlexportApiClientID            $DeveloperEnvironmentSettings.FlexportApiClientID `
-            -FlexportApiClientSecret        $DeveloperEnvironmentSettings.FlexportApiClientSecret `
-            -GoogleAnalyticsMeasurementId   $DeveloperEnvironmentSettings.GoogleAnalyticsMeasurementId
+            -FlexportApiClientSecret        $DeveloperEnvironmentSettings.FlexportApiClientSecret
     }
     finally {
         Pop-Location

--- a/src/azure/pipelines/azure-pipelines.yml
+++ b/src/azure/pipelines/azure-pipelines.yml
@@ -30,7 +30,7 @@ stages:
         key: ./src/website-content/package-lock.json
         path: ./src/releasables/frontend/content
 
-    - pwsh: ./build.ps1 -BuildNumber $(Build.BuildNumber) -BuildUrl "https://dev.azure.com/flexport-earth/Earth/_build/results?buildId=$(Build.BuildId)" -FlexportApiClientId $(FlexportApiClientId) -FlexportApiClientSecret $(FlexportApiClientSecret) -GoogleAnalyticsMeasurementId $(GoogleAnalyticsMeasurementId)
+    - pwsh: ./build.ps1 -BuildNumber $(Build.BuildNumber) -BuildUrl "https://dev.azure.com/flexport-earth/Earth/_build/results?buildId=$(Build.BuildId)" -FlexportApiClientId $(FlexportApiClientId) -FlexportApiClientSecret $(FlexportApiClientSecret)
       displayName: 'Build Script'
       workingDirectory: './src'
 

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -14,11 +14,7 @@ param (
 
     [Parameter(Mandatory = $true)]
     [String]
-    $FlexportApiClientSecret,
-
-    [Parameter(Mandatory = $true)]
-    [String]
-    $GoogleAnalyticsMeasurementId
+    $FlexportApiClientSecret
 )
 
 Set-StrictMode –Version latest
@@ -61,11 +57,7 @@ function Build-Website {
 
         [Parameter(Mandatory = $true)]
         [String]
-        $FlexportApiClientSecret,
-
-        [Parameter(Mandatory = $true)]
-        [String]
-        $GoogleAnalyticsMeasurementId
+        $FlexportApiClientSecret
     )
 
     Write-Information ""
@@ -76,7 +68,7 @@ function Build-Website {
         Write-Error "Failed to install dependencies, see previous log entries."
     }
 
-    $env:FLEXPORT_API_CLIENT_ID = "$FlexportApiClientId"; $env:FLEXPORT_API_CLIENT_SECRET = "$FlexportApiClientSecret"; $env:NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID = "$GoogleAnalyticsMeasurementId"; npm run build
+    $env:FLEXPORT_API_CLIENT_ID = "$FlexportApiClientId"; $env:FLEXPORT_API_CLIENT_SECRET = "$FlexportApiClientSecret"; npm run build
     if (!$?) {
         Write-Error "Failed to build the website, see previous log entries."
     }
@@ -137,11 +129,7 @@ function Invoke-BuildWorkflow {
 
         [Parameter(Mandatory = $true)]
         [String]
-        $FlexportApiClientSecret,
-
-        [Parameter(Mandatory = $true)]
-        [String]
-        $GoogleAnalyticsMeasurementId
+        $FlexportApiClientSecret
     )
 
     # Validate all the PowerShell scripts
@@ -169,8 +157,7 @@ function Invoke-BuildWorkflow {
 
         Build-Website `
             -FlexportApiClientId            $FlexportApiClientId `
-            -FlexportApiClientSecret        $FlexportApiClientSecret `
-            -GoogleAnalyticsMeasurementId   $GoogleAnalyticsMeasurementId
+            -FlexportApiClientSecret        $FlexportApiClientSecret
 
         Test-UnitAndComponentFunctionality
 
@@ -192,8 +179,7 @@ Invoke-BuildWorkflow `
     -BuildNumber                    $BuildNumber `
     -BuildUrl                       $BuildUrl `
     -FlexportApiClientId            $FlexportApiClientId `
-    -FlexportApiClientSecret        $FlexportApiClientSecret `
-    -GoogleAnalyticsMeasurementId   $GoogleAnalyticsMeasurementId
+    -FlexportApiClientSecret        $FlexportApiClientSecret
 
 Write-Information "Earth website build completed!"
 Write-Information ""

--- a/src/website-content/lib/google-analytics/ga4.ts
+++ b/src/website-content/lib/google-analytics/ga4.ts
@@ -1,7 +1,11 @@
+import getConfig from 'next/config';
+
+const { publicRuntimeConfig } = getConfig();
+
 // This code adopted from:
 // https://dev.to/asross311/strongly-typed-google-analytics-v4-with-nextjs-4g13
 
-export const GA4_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID ?? '';
+export const GA4_MEASUREMENT_ID = publicRuntimeConfig.NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID ?? '';
 
 export const pageview = (url: URL) => {
     window.gtag('config', GA4_MEASUREMENT_ID, {

--- a/src/website-content/next.config.js
+++ b/src/website-content/next.config.js
@@ -33,6 +33,10 @@ const nextConfig = {
     images: {
       layoutRaw: true
     }
+  },
+  publicRuntimeConfig: {
+    staticFolder: '/static',
+    NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_MEASUREMENT_ID
   }
 }
 


### PR DESCRIPTION
…y-time variable instead of build time so that Earth can be built once (in dev) but allow each runtime environment to provide its own GA Tracking ID so that the GA stats report to the correct GA account.