### PR TITLE
earth-306: Modifies cache-control to set stale-if-error to inform cac…

### DIFF
--- a/src/website-content/pages/index.tsx
+++ b/src/website-content/pages/index.tsx
@@ -14,7 +14,7 @@ type CountryInfo = {
 export async function getServerSideProps({ res }: {res: NextApiResponse }) {
   res.setHeader(
     'Cache-Control',
-    'public, s-maxage=86400, stale-while-revalidate=59'
+    'public, maxage=86400, stale-while-revalidate=86400 stale-if-error=86400'
   )
 
   const countriesApi = getRestCountriesApiClient();


### PR DESCRIPTION
…hes that they can reused stale cached version of the page in the event the backend is failing to generate a new version.