### PR TITLE
earth-344: Modifies the CDN Health Probe Path to hit /robots.txt inst…

### DIFF
--- a/src/releasables/frontend/infrastructure/cdn-front-door.bicep
+++ b/src/releasables/frontend/infrastructure/cdn-front-door.bicep
@@ -83,7 +83,7 @@ resource originGroup 'Microsoft.Cdn/profiles/originGroups@2021-06-01' = {
       successfulSamplesRequired: 3
     }
     healthProbeSettings: {
-      probePath: '/'
+      probePath: '/robots.txt'
       probeRequestType: 'HEAD'
       probeProtocol: 'Http'
       probeIntervalInSeconds: 100


### PR DESCRIPTION
…ead of the root / Homepage because the Homepage takes resources to generate, makes API calls etc.

The probes are currently hitting the Homepage and driving a lot of API calls to the Flexport APIs.